### PR TITLE
fix flaky test testNoneAccessWithXmlElements

### DIFF
--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestPropertyVisibility.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/introspect/TestPropertyVisibility.java
@@ -113,7 +113,14 @@ public class TestPropertyVisibility
     public void testNoneAccessWithXmlElements() throws Exception
     {
         NoneAccessBean input = new NoneAccessBean(new Foo44());
+        
+        /* Earlier
         assertEquals(a2q("{'object':{'foo':{'foo':'bar'}},'other':null}"),
                 MAPPER.writeValueAsString(input));
+        */
+
+        assertTrue(
+            a2q("{'object':{'foo':{'foo':'bar'}},'other':null}").equals(MAPPER.writeValueAsString(input))
+            || a2q("{'other':null,'object':{'foo':{'foo':'bar'}}}").equals(MAPPER.writeValueAsString(input)));
     }
 }


### PR DESCRIPTION
Fixed flaky test `testNoneAccessWithXmlElements`

The test `testNoneAccessWithXmlElements` compares the result of `MAPPER.writeValueAsString(input)` with a hardcoded string. However, the function `com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString()` would not always return JSON properties in the same order. 